### PR TITLE
fix for 'TypeError: Object #<ServerResponse> has no method 'type' error'

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports=function(invalidateTimeInMilliseconds,parameters){
 
     return function(request,response,next){
         if(parameters && parameters.type){
-            response.type(parameters.type);
+            response.setHeader('Content-Type', parameters.type);
         }
         if (request.method == 'GET') {
             cache.get(request.originalUrl,function(err,value){


### PR DESCRIPTION
Running Express 2.X, when setting the 'type' option for a given cached route would cause this runtime error:

TypeError: Object #<ServerResponse> has no method 'type'
    at Object.handle (/Users/giorgiog/Projects/Virtuoso/maestro/server/output/node_modules/express-view-cache/index.js:32:22)

Rather than setting response.**type** (which doesn't seem to exist), I simply call response.setHeader...
